### PR TITLE
feat(ci): export Coverlet/Cobertura coverage for Coverage Dashboard [CORE-3368]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,33 @@ jobs:
       - name: Build the Library
         run: dotnet build src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.csproj --configuration Release --no-restore
 
-      - name: Run Library Tests
-        # This step will pass if no tests are found, but will run them once added.
-        run: dotnet test src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.csproj --no-build
-        
+      - name: Restore NuGet packages for Tests
+        run: dotnet restore src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/Oddin.OddsFeedSdk.Tests.csproj
+
+      - name: Run Library Tests with Coverage
+        run: >
+          dotnet test src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/Oddin.OddsFeedSdk.Tests.csproj
+          --collect:"XPlat Code Coverage"
+          --results-directory ./coverage-results
+
+      - name: Rename Cobertura report for skald
+        run: |
+          # Coverlet writes coverage.cobertura.xml under a guid dir; skald only
+          # accepts coverage.xml, so copy to the expected name at a fixed path.
+          src=$(find ./coverage-results -name 'coverage.cobertura.xml' | head -1)
+          if [ -z "$src" ]; then
+            echo "No coverage report produced — Coverlet did not run."
+            exit 1
+          fi
+          cp "$src" ./coverage.xml
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          if-no-files-found: warn
+
       - name: Extract version from tag
         id: version
         run: |

--- a/src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/CoverageBootstrapTest.cs
+++ b/src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/CoverageBootstrapTest.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Oddin.OddsFeedSdk.Tests
+{
+    // CORE-3368: bootstrap test so `dotnet test` actually starts a test runner
+    // and Coverlet can emit a Cobertura coverage report covering the SDK's
+    // classes. Replace with real test cases as the SDK gains test coverage.
+    public class CoverageBootstrapTest
+    {
+        [Fact]
+        public void Bootstrap()
+        {
+        }
+    }
+}

--- a/src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/Oddin.OddsFeedSdk.Tests.csproj
+++ b/src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/Oddin.OddsFeedSdk.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Oddin.OddsFeedSdk\Oddin.OddsFeedSdk.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Wires up Coverlet so netcoresdk appears on the Grafana Coverage Dashboard, matching the existing setup of `gosdk` (which also has no real tests today but ships a zero-coverage Go textfmt profile via `go test -cover ./...`).

## Why a new test project (and not just CI)

Unlike Go's `go test -cover ./...`, which walks every package and emits a `mode: set` profile with all-zero entries even when no `_test.go` files exist, **Coverlet is runtime instrumentation** plugged into the VSTest runner via `dotnet test --collect:"XPlat Code Coverage"`. It only captures data while the runner is actually executing tests against a test assembly.

The current CI step (`dotnet test src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.csproj`) targets the **library** csproj — the inline comment admits *"This step will pass if no tests are found, but will run them once added."* `dotnet test` against a non-test project just exits with "no tests are available," so Coverlet never attaches and no report is produced.

To get the equivalent shape (all SDK classes enumerated, 0% covered) two pieces are needed:

1. **A test project that `dotnet test` can actually run against**, so the VSTest runner starts and Coverlet has somewhere to attach.
2. **A `ProjectReference` from the test project to the SDK** so Coverlet's VS data collector includes the SDK assembly in its instrumentation scope. With this reference, every SDK class is enumerated in the Cobertura output even though the bootstrap test doesn't exercise any of them.

The new test project is the foundation for real tests. When real test cases land, they replace the bootstrap stub and the same Coverlet wiring keeps producing reports with real numbers.

## Verified shape (from this PR's CI run)

CI build succeeded; `coverage-report` artifact contains an 81 KB `coverage.xml` (Cobertura):

```
1 package, 252 classes enumerated
lines-valid     = 8281       lines-covered     = 0     line-rate   = 0
branches-valid  = 1947       branches-covered  = 0     branch-rate = 0
```

After merge, skald's daily 06:00 Prague poll downloads this artifact, autodetects Cobertura (filename `coverage.xml` matches), parses the line and branch rates, and writes a row to `mart_grafana.coverage_reports`. The dashboard will show `oddin-gg/netcoresdk` at 8,281 lines / 0% with branch coverage also at 0% — same shape as `oddin-gg/gosdk` today.

## What's in the diff

- **`src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/Oddin.OddsFeedSdk.Tests.csproj`** *(new)* — test project targeting `net6.0`, with `Microsoft.NET.Test.Sdk` 17.6.0, `xunit` 2.4.2, `xunit.runner.visualstudio` 2.4.5, `coverlet.collector` 6.0.0, and a `ProjectReference` to the SDK so Coverlet instruments the SDK assembly during the test run.
- **`src/Oddin.OddsFeedSdk/Oddin.OddsFeedSdk.Tests/CoverageBootstrapTest.cs`** *(new)* — a single empty `[Fact] public void Bootstrap()` to make the runner start. Replaceable.
- **`.github/workflows/ci.yml`** — replace the no-op `Run Library Tests` step with a `dotnet test` against the new Tests project plus `--collect:"XPlat Code Coverage"`; rename Coverlet's `coverage.cobertura.xml` (under a guid-named directory) to a fixed `coverage.xml` since skald only matches that filename; upload as `coverage-report`.

## Targeting `main`

Per CORE-3368 scope, this targets `main` even though netcoresdk's default branch is `develop`. CI-only change, no production runtime impact, so the develop→main staging step doesn't apply.

## Compared to smoke

Different shape than smoke. Smoke has real unit + system tests, uploads merged Go covdata + Cobertura xml, and shows real coverage numbers (~60%). netcoresdk after this PR mirrors gosdk's "no tests yet, ship zero-coverage to make the gap visible on the dashboard" pattern — not smoke's "instrumented end-to-end" pattern. When real tests land later, the wiring already works and the numbers populate accordingly.

[Link to JIRA ticket](https://oddingg.atlassian.net/browse/CORE-3368)